### PR TITLE
Fix the abstration remaining method

### DIFF
--- a/src/Md5Hash.php
+++ b/src/Md5Hash.php
@@ -7,6 +7,17 @@ use Illuminate\Contracts\Hashing\Hasher;
 class Md5Hash implements Hasher
 {
     /**
+     * Get information about the given hashed value.
+     *
+     * @param  string  $hashedValue
+     * @return array
+     */
+    public function info($hashedValue)
+    {
+        return $hashedValue;
+    }
+    
+    /**
      * Hash the given value.
      *
      * @param  string $value


### PR DESCRIPTION
Fix error:
Class Matriphe\Md5Hash\Md5Hash contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Illuminate\Contracts\Hashing\Hasher::info)